### PR TITLE
Change regex in extractLoader.js

### DIFF
--- a/src/extractLoader.js
+++ b/src/extractLoader.js
@@ -40,7 +40,7 @@ function extractLoader(content) {
 
             // If the required file is a JS-file, we just evaluate it with node's require
             // This is necessary because of the css-loader which uses a helper module (css-base.js) to export stuff
-            if (/\.js$/i.test(resourcePath)) {
+            if (/css-base\.js$/i.test(resourcePath)) {
                 return require(absPath);
             }
 


### PR DESCRIPTION
The regex used in the loader is a bit overzealous and prevents inclusion of scripts in the same manner allowed for images and styles. This should limit it to only the applicable file that needs to be executed, though I would like to change the conditional to something that indicates more absolutely that css-loader is being used.
