### PR TITLE
Feature: add publicPath query option

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,34 @@ into
 Options
 ------------------------------------------------------------------------
 
-The are currently no options.<br>
-You need one? Then you should think about:
+There is currently exactly one option: `publicPath`.
+If you are using a relative `publicPath` in webpack's [output options]() and extracting to a file with the `file-loader`, you might need this to account for the location of your extracted file.
+
+Example:
+```js
+module.exports = {
+    output: {
+        path: path.resolve( './dist' ),
+        publicPath: 'dist/'
+    },
+    module: {
+        loaders: [
+            {
+                test: /\.css$/,
+                loaders: [
+                    // target file: dist/assets/file.css
+                    "file?name=assets/[name].[ext]",
+                    // back up one directory to reach "dist/"
+                    "extract?publicPath=../",
+                    "css"
+                ]
+            }
+        ]
+    }
+};
+```
+
+You need another option? Then you should think about:
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Options
 ------------------------------------------------------------------------
 
 There is currently exactly one option: `publicPath`.
-If you are using a relative `publicPath` in webpack's [output options]() and extracting to a file with the `file-loader`, you might need this to account for the location of your extracted file.
+If you are using a relative `publicPath` in webpack's [output options](http://webpack.github.io/docs/configuration.html#output-publicpath) and extracting to a file with the `file-loader`, you might need this to account for the location of your extracted file.
 
 Example:
 ```js

--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
     "rimraf": "^2.5.1",
     "style-loader": "^0.13.0",
     "webpack": "^1.12.13"
+  },
+  "dependencies": {
+    "loader-utils": "^0.2.16"
   }
 }

--- a/src/extractLoader.js
+++ b/src/extractLoader.js
@@ -1,5 +1,6 @@
 import vm from "vm";
 import path from "path";
+import { parseQuery } from "loader-utils";
 
 /**
  * @name LoaderContext
@@ -26,6 +27,8 @@ const rndPlaceholder = "__EXTRACT_LOADER_PLACEHOLDER__" + rndNumber() + rndNumbe
  */
 function extractLoader(content) {
     const callback = this.async();
+    const query = parseQuery(this.query);
+    const publicPath = typeof query.publicPath !== "undefined" ? query.publicPath : this.options.output.publicPath;
     const dependencies = [];
     const script = new vm.Script(content, {
         filename: this.resourcePath,
@@ -60,7 +63,7 @@ function extractLoader(content) {
     Promise.all(dependencies.map(loadModule, this))
         .then(sources => sources.map(
             // runModule may throw an error, so it's important that our promise is rejected in this case
-            (src, i) => runModule(src, dependencies[i], this.options.output.publicPath)
+            (src, i) => runModule(src, dependencies[i], publicPath)
         ))
         .then(results => sandbox.module.exports.toString()
             .replace(new RegExp(rndPlaceholder, "g"), () => results.shift())

--- a/test/extractLoader.test.js
+++ b/test/extractLoader.test.js
@@ -109,6 +109,16 @@ describe("extractLoader", () => {
             expect(imgHtml).to.have.content.that.match(/<img src="\/test\/hi-dist\.jpg">/);
         })
     );
+    it("should override the configured publicPath with the publicPath query option", () =>
+        compile({ testModule: "img.html", publicPath: "/test/", query: "?publicPath=/other/" }).then(() => {
+            const imgHtml = path.resolve(__dirname, "dist/img-dist.html");
+            const imgJpg = path.resolve(__dirname, "dist/hi-dist.jpg");
+
+            expect(imgHtml).to.be.a.file();
+            expect(imgJpg).to.be.a.file();
+            expect(imgHtml).to.have.content.that.match(/<img src="\/other\/hi-dist\.jpg">/);
+        })
+    );
     it("should report syntax errors", () =>
         compile({ testModule: "error.js" }).then(
             () => { throw new Error("Did not throw expected error"); },
@@ -127,7 +137,8 @@ describe("extractLoader", () => {
             },
             cacheable() {
                 cacheableCalled = true;
-            }
+            },
+            options: { output: {} }
         };
         let cacheableCalled = false;
 

--- a/test/support/compile.js
+++ b/test/support/compile.js
@@ -1,7 +1,7 @@
 import webpack from "webpack";
 import path from "path";
 
-export default function ({ testModule, publicPath }) {
+export default function ({ testModule, publicPath, query = "" }) {
     const testModulePath = path.resolve(__dirname, "../modules/", testModule);
 
     return new Promise((resolve, reject) => {
@@ -20,14 +20,14 @@ export default function ({ testModule, publicPath }) {
                         loaders: [
                             // appending -dist so we can check if url rewriting is working
                             "file?name=[name]-dist.[ext]",
-                            path.resolve(__dirname, "../../lib/extractLoader.js")
+                            path.resolve(__dirname, "../../lib/extractLoader.js") + query
                         ]
                     },
                     {
                         test: /\.html$/,
                         loaders: [
                             "file?name=[name]-dist.[ext]",
-                            path.resolve(__dirname, "../../lib/extractLoader.js"),
+                            path.resolve(__dirname, "../../lib/extractLoader.js") + query,
                             "html?" + JSON.stringify({
                                 attrs: ["img:src", "link:href"]
                             })
@@ -37,7 +37,7 @@ export default function ({ testModule, publicPath }) {
                         test: /\.css$/,
                         loaders: [
                             "file?name=[name]-dist.[ext]",
-                            path.resolve(__dirname, "../../lib/extractLoader.js"),
+                            path.resolve(__dirname, "../../lib/extractLoader.js") + query,
                             "css"
                         ]
                     },


### PR DESCRIPTION
Hi!

First: Thanks for releasing this wonderful loader! This pull request allows for the `publicPath` to be set via query parameter.

Let me try to explain why I need this.

My project's directory structure looks like this:
```
/dist                            (=> publicPath)
/dist/main.js                    (=> bundled webpack output)
/dist/assets/f00b43-main.css     (=> output of 'file-loader!extract-loader!css-loader')
/dist/assets/f001ce-img.png      (=> output of 'file-loader!img-loader', ref'd by main.css)
/index.html                      (=> browser entry point)

(other paths are just sources for webpack)
```

I'm using a relative `publicPath` in my webpack config, so that the bundled `main.js` and extracted CSS don't depend on the path where I deploy my project:
```js
module.exports = {
  output: {
    path: path.resolve( 'dist/' ),
    publicPath: 'dist/', // no leading slash!
    filename: '[name].js'
  },
  /* ... */
```

I've set up my `file-loader` to put files into the `assets` subdirectory inside the output path:
```js
  /* ... */
  fileLoader: {
    name: 'assets/[name]-[sha1:hash:hex:6].[ext]'
  }
};
```

Bundling and hot reload (sometimes finicky to get right in conjunction with `publicPath`) both work as expected with this setup.

However, issues arise when the extracted and `file-loader`'ed CSS file has references to other files, images for example. Because of my relative `publicPath` the `extract-loader` generates a CSS file that contains `url(dist/assets/f001ce-img.png)` just like you would expect. But since the `file-loader` puts the extracted CSS into a file that is _already in that same directory_, that URL now point at `dist/assets/dist/assets/f001ce-img.png`. (Note: the problem would even arise if I'd omit the sub directory in my file loader config.)

To alleviate that issue I want to be able to set the public path manually when extracting and passing the output to the `file-loader`. In my case, I'd just add `?publicPath=../` to the `extract-loader` to step back up into `dist/` from `dist/assets/`.

Maybe I'm taking things too far with my setup, but the change is pretty minor and backwards compatible. Also, the loader-wrapper-thing in `extract-text-webpack-plugin` [has the same option](https://github.com/webpack/extract-text-webpack-plugin#api). :)