### PR TITLE
Webpack doesn't cache a module if it requires a url with a querystring

### DIFF
--- a/src/extractLoader.js
+++ b/src/extractLoader.js
@@ -36,7 +36,7 @@ function extractLoader(content) {
     });
     const sandbox = {
         require: (resourcePath) => {
-            const absPath = path.resolve(path.dirname(this.resourcePath), resourcePath);
+            const absPath = path.resolve(path.dirname(this.resourcePath), resourcePath).split("?")[0];
 
             // Mark the file as dependency so webpack's watcher is working
             this.addDependency(absPath);


### PR DESCRIPTION
Consider that the following two modules pass through `file!extract!css`:

font.css:
```css
@font-face {
  font-family: 'FancyFont';
  src: url('webfont.woff2?v=1.0.0') format('woff2');
  /*                     ^^^^^^^^                 */
}
```

main.css
```css
.fancy {
  font-family: 'FancyFont';
}
```

I can't explain the why, but the module `font.css` is never cached by webpack if the querystring `?v=1.0.0` is appended to the path. So, when a change is made in `main.css`, both chunks (`main.css` and `font.css`) is compiled and emitted (slowing the rebuild).

If we remove the querystring part from font path, a change in `main.css` will emit only the second chunk (as expected).

Trying to find a solution, I removed the querystring from dependency's absolute path:

```js
const absPath = path.resolve(path.dirname(this.resourcePath), resourcePath).split('?')[0]
```

It seems it's working, but I'm very newbie with webpack internals and don't know if this is an acceptable solution.
