### PR TITLE
Fix deprecated use of loader-utils. Closes #18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ os:
   - linux
 language: node_js
 node_js:
-  - "0.12"
   - "4"
   - "5"
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "webpack": "^1.12.13"
   },
   "dependencies": {
-    "loader-utils": "^0.2.16"
+    "loader-utils": "^1.1.0"
   }
 }

--- a/src/extractLoader.js
+++ b/src/extractLoader.js
@@ -1,6 +1,6 @@
 import vm from "vm";
 import path from "path";
-import { parseQuery } from "loader-utils";
+import { getOptions } from "loader-utils";
 
 /**
  * @name LoaderContext
@@ -27,8 +27,8 @@ const rndPlaceholder = "__EXTRACT_LOADER_PLACEHOLDER__" + rndNumber() + rndNumbe
  */
 function extractLoader(content) {
     const callback = this.async();
-    const query = parseQuery(this.query);
-    const publicPath = typeof query.publicPath !== "undefined" ? query.publicPath : this.options.output.publicPath;
+    const options = getOptions(this) || {};
+    const publicPath = typeof options.publicPath !== "undefined" ? options.publicPath : this.options.output.publicPath;
     const dependencies = [];
     const script = new vm.Script(content, {
         filename: this.resourcePath,


### PR DESCRIPTION
See #18 

Also dropped node 0.12 from testing since the latest version of loader-utils (and webpack) no longer support it.