### PR TITLE
Add support for explicit loader chains in extracted files

### DIFF
--- a/src/extractLoader.js
+++ b/src/extractLoader.js
@@ -42,8 +42,9 @@ function extractLoader(content) {
             this.addDependency(absPath);
 
             // If the required file is a JS-file, we just evaluate it with node's require
-            // This is necessary because of the css-loader which uses a helper module (css-base.js) to export stuff
-            if (/css-base\.js$/i.test(resourcePath)) {
+            // This is necessary because of the css-loader which uses a helper module (css-base.js) to export stuff.
+            // If the required file should be processed by a loader we do not touch it (even if it is a .js file).
+            if (/^[^!]*css-base\.js$/i.test(resourcePath)) {
                 return require(absPath);
             }
 

--- a/test/extractLoader.test.js
+++ b/test/extractLoader.test.js
@@ -119,6 +119,15 @@ describe("extractLoader", () => {
             expect(imgHtml).to.have.content.that.match(/<img src="\/other\/hi-dist\.jpg">/);
         })
     );
+    it("should support explicit loader chains", () => {
+        return compile({ testModule: "loader.html" }).then(() => {
+            const loaderHtml = path.resolve(__dirname, "dist/loader-dist.html");
+            const errJs = path.resolve(__dirname, "dist/err.js");
+
+            expect(loaderHtml).to.be.a.file();
+            expect(errJs).to.have.content("this is a syntax error\n");
+        });
+    });
     it("should report syntax errors", () =>
         compile({ testModule: "error.js" }).then(
             () => { throw new Error("Did not throw expected error"); },

--- a/test/modules/loader.html
+++ b/test/modules/loader.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Hello World</title>
+</head>
+<body>
+    <script src="${require('!!file?name=err.js!./error.js')}"></script>
+</body>
+</html>

--- a/test/support/compile.js
+++ b/test/support/compile.js
@@ -29,7 +29,8 @@ export default function ({ testModule, publicPath, query = "" }) {
                             "file?name=[name]-dist.[ext]",
                             path.resolve(__dirname, "../../lib/extractLoader.js") + query,
                             "html?" + JSON.stringify({
-                                attrs: ["img:src", "link:href"]
+                                attrs: ["img:src", "link:href"],
+                                interpolate: true
                             })
                         ]
                     },


### PR DESCRIPTION
Hi @jhnns and @meaku 🙂 
I have a problem with the extract-loader when it comes to explicit loader strings inside your extrated files.
For example this `<script src="${require('!!file?name=err.js!./error.js')}"></script>` in a file that is extracted with extract-loader leads to the following error:

```
Module build failed: Error: Cannot find module '/Users/xyz/workspace/repos/github/extract-loader/test/modules/!!file?name=err.js!./error.js'
    at Function.Module._resolveFilename (module.js:469:15)
    at Function.Module._load (module.js:417:25)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at /Users/xyz/workspace/repos/github/extract-loader/lib/extractLoader.js:74:24
    at require (/Users/xyz/workspace/repos/github/extract-loader/lib/extractLoader.js:56:33)
```
This is caused by calling the native node.js `require()` on all .js-files without checking if they are only referencing a file path or a whole loader chain. This PR adds a simple check for this. Let me know what you think 👍 

See you!
Ben

P.S.: I added tests for you to reproduce the behavior.
