### PR TITLE
Add rudimentary ES2015 module transpilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-flowtype": "^2.33.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsdoc": "^3.1.0",
-    "file-loader": "^0.11.1",
+    "file-loader": "^1.0.0",
     "html-loader": "^0.5.0",
     "istanbul": "^0.4.2",
     "mocha": "^3.4.1",

--- a/src/extractLoader.js
+++ b/src/extractLoader.js
@@ -106,6 +106,13 @@ function loadModule(request) {
  * @returns {string}
  */
 function runModule(src, filename, publicPath = "") {
+    // Rudimentary "transpilation" of ES 2015 modules (e.g file-loader 1.0.0+)
+    // TODO: Find a better way to "execute" ES 2015 modules in node context
+    // "Transpile" imports
+    src = src.replace(/^import\s+(.+)\s+from\s+([^;]+);?$/, "var $1 = require($2);");
+    // "Transpile" default export (other exports are not supported at the moment)
+    src = src.replace(/^\s*export\s+default\s*/, "module.exports = ");
+
     const script = new vm.Script(src, {
         filename,
         displayErrors: true,


### PR DESCRIPTION
The better approach is to run babel-loader before extract-loader, but this "transpilation" at least enables file-loader 1.0.0 to integrate without syntax errors.