### PR TITLE
Fix incompatibility with css-loader 0.28.8

### DIFF
--- a/src/extractLoader.js
+++ b/src/extractLoader.js
@@ -43,7 +43,7 @@ function extractLoader(content) {
 
             // If the required file is the css-loader helper, we just require it with node's require.
             // If the required file should be processed by a loader we do not touch it (even if it is a .js file).
-            if (/^[^!]*css-base\.js$/i.test(resourcePath)) {
+            if (/^[^!]*node_modules.*[/\\]css-loader[/\\].*\.js$/i.test(resourcePath)) {
                 // Mark the file as dependency so webpack's watcher is working for css-base.js. Other dependencies
                 // are automatically added by loadModule() below
                 this.addDependency(absPath);

--- a/test/extractLoader.test.js
+++ b/test/extractLoader.test.js
@@ -99,6 +99,7 @@ describe("extractLoader", () => {
             expect(dependencies.sort()).to.eql(
                 [
                     "/node_modules/css-loader/lib/css-base.js",
+                    "/node_modules/css-loader/lib/url/escape.js",
                     "/test/modules/hi.jpg",
                     "/test/modules/img.css",
                     "/test/modules/stylesheet.html",


### PR DESCRIPTION
Currently extract-loader does not work with css-loader 0.28.8, because we need to require an additionial lib file they added.
See: https://github.com/webpack-contrib/css-loader/commit/8897d446c88eb7a6585a7954ae8766a7242c12da

I changed the regex so that it should be less error prone for future css-loader updates 😆 