### PR TITLE
fix:  when a package is installed using CNPM   'TypeError require(...……) is not a function'  occurs

### DIFF
--- a/src/extractLoader.js
+++ b/src/extractLoader.js
@@ -40,7 +40,7 @@ function extractLoader(content) {
 
             // If the required file is a css-loader helper, we just require it with node's require.
             // If the required file should be processed by a loader we do not touch it (even if it is a .js file).
-            if (/^[^!]*node_modules[/\\]css-loader[/\\].*\.js$/i.test(absPath)) {
+            if (/^[^!]*node_modules[/\\](_css-loader@[.\d]+@)*css-loader[/\\].*\.js$/i.test(absPath)) {
                 // Mark the file as dependency so webpack's watcher is working for the css-loader helper.
                 // Other dependencies are automatically added by loadModule() below
                 this.addDependency(absPath);


### PR DESCRIPTION
When I used CNPM to install the package, 'TypeError require(... ...... ) is not a function error' occurred, mainly because the path of CNPM starts with _ when installing the package, such as 'node_modules/_css-loader@0.28.11@css-loader/lib/css-base.js', so I modified the regular expression to solve this problem