### PR TITLE
Adds the `--save-dev` flag to the install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ The extract-loader works similar to the [extract-text-webpack-plugin](https://gi
 Installation
 ------------------------------------------------------------------------
 
-`npm install extract-loader`
+```bash
+$ npm install extract-loader --save-dev
+```
 
 <br>
 


### PR DESCRIPTION
To be more consistent with the other loaders' documentation, but also for newbs who might just copy-paste and thus accidentally put it in their non-development-only dependencies.