### PR TITLE
feat: accept function as publicPath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,9 @@ Options
 ------------------------------------------------------------------------
 
 There is currently exactly one option: `publicPath`.
-If you are using a relative `publicPath` in webpack's [output options](https://webpack.js.org/configuration/output/#output-publicpath) and extracting to a file with the `file-loader`, you might need this to account for the location of your extracted file.
+If you are using a relative `publicPath` in webpack's [output options](https://webpack.js.org/configuration/output/#output-publicpath) and extracting to a file with the `file-loader`, you might need this to account for the location of your extracted file. `publicPath` may be defined as a string or a function that accepts current [loader context](https://webpack.js.org/api/loaders/#the-loader-context) as single argument.
 
-Example:
+Example with publicPath option as a string:
 
 ```js
 module.exports = {
@@ -196,6 +196,42 @@ module.exports = {
                         loader: "extract-loader",
                         options: {
                             publicPath: "../",
+                        }
+                    },
+                    {
+                        loader: "css-loader",
+                    },
+                ],
+            }
+        ]
+    }
+};
+```
+
+Example with publicPath option as a function:
+
+```js
+module.exports = {
+    output: {
+        path: path.resolve("./dist"),
+        publicPath: "dist/"
+    },
+    module: {
+        rules: [
+            {
+                test: /\.css$/,
+                use: [
+                    {
+                        loader: "file-loader",
+                        options: {
+                            name: "assets/[name].[ext]",
+                        },
+                    },
+                    {
+                        loader: "extract-loader",
+                        options: {
+                            // dynamically return a relative publicPath based on how deep in directory structure the loaded file is in /src/ directory
+                            publicPath: (context) => '../'.repeat(path.relative(path.resolve('src'), context.context).split('/').length),
                         }
                     },
                     {

--- a/src/extractLoader.js
+++ b/src/extractLoader.js
@@ -173,7 +173,7 @@ function rndNumber() {
  */
 function getPublicPath(options, context) {
     if ("publicPath" in options) {
-        return options.publicPath;
+        return typeof options.publicPath === 'function' ? options.publicPath(context) : options.publicPath;
     }
 
     if (context.options && context.options.output && "publicPath" in context.options.output) {

--- a/src/extractLoader.js
+++ b/src/extractLoader.js
@@ -173,7 +173,7 @@ function rndNumber() {
  */
 function getPublicPath(options, context) {
     if ("publicPath" in options) {
-        return typeof options.publicPath === 'function' ? options.publicPath(context) : options.publicPath;
+        return typeof options.publicPath === "function" ? options.publicPath(context) : options.publicPath;
     }
 
     if (context.options && context.options.output && "publicPath" in context.options.output) {

--- a/test/extractLoader.test.js
+++ b/test/extractLoader.test.js
@@ -155,6 +155,24 @@ describe("extractLoader", () => {
                 /<img src="\/other\/hi-dist\.jpg">/
             );
         }));
+    it("should execute options.publicPath if it's defined as a function", done => {
+        let publicPathCalledWithContext = false;
+        const loaderContext = {
+            async: () => () => done(),
+            cacheable() {},
+            query: {
+                publicPath: context => {
+                    publicPathCalledWithContext = context === loaderContext;
+
+                    return "";
+                },
+            },
+        };
+
+        extractLoader.call(loaderContext, "");
+
+        expect(publicPathCalledWithContext).to.equal(true);
+    });
     it("should support explicit loader chains", () => compile({testModule: "loader.html"}).then(() => {
         const loaderHtml = path.resolve(__dirname, "dist/loader-dist.html");
         const errJs = path.resolve(__dirname, "dist/err.js");


### PR DESCRIPTION
Allow `publicPath` option to be a function that returns the publicPath string that could be determined based on current context.

In my use case I need to return a relative path with varying depth depending on how deep in dir structure the loaded file is:
```
publicPath: (context) => '../'.repeat(path.relative(srcPath, context.context).split('/').length)
```