### PR TITLE
add failing test cases for extracting scripts from html entry points

### DIFF
--- a/test/extractLoader.test.js
+++ b/test/extractLoader.test.js
@@ -82,6 +82,28 @@ describe("extractLoader", () => {
                 /<img src="hi-dist\.jpg">/
             );
         }));
+    it("should extract the script.html as file, emit the referenced script and rewrite the url", () =>
+        compile({testModule: "script.html"}).then(() => {
+            const scriptHtml = path.resolve(__dirname, "dist/script-dist.html");
+            const scriptJs = path.resolve(__dirname, "dist/simple-dist.js");
+
+            expect(scriptHtml).to.be.a.file();
+            expect(scriptJs).to.be.a.file();
+            expect(scriptHtml).to.have.content.that.match(
+                /<script src="simple-dist\.js">/
+            );
+        }));
+    it("should extract the esm.html as file, emit the referenced es module and rewrite the url", () =>
+        compile({testModule: "esm.html"}).then(() => {
+            const esmHtml = path.resolve(__dirname, "dist/esm-dist.html");
+            const esmJs = path.resolve(__dirname, "dist/esm-dist.js");
+
+            expect(esmHtml).to.be.a.file();
+            expect(esmJs).to.be.a.file();
+            expect(esmHtml).to.have.content.that.match(
+                /<script src="esm-dist\.js">/
+            );
+        }));
     it("should extract the img.css as file, emit the referenced img and rewrite the url", () =>
         compile({testModule: "img.css"}).then(() => {
             const imgCss = path.resolve(__dirname, "dist/img-dist.css");

--- a/test/modules/esm.html
+++ b/test/modules/esm.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Hello World</title>
+</head>
+<body>
+    <script src="esm.js"></script>
+</body>
+</html>

--- a/test/modules/esm.js
+++ b/test/modules/esm.js
@@ -1,0 +1,1 @@
+export * from 'btoa'

--- a/test/modules/script.html
+++ b/test/modules/script.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Hello World</title>
+</head>
+<body>
+    <script src="simple.js"></script>
+</body>
+</html>

--- a/test/support/compile.js
+++ b/test/support/compile.js
@@ -53,7 +53,7 @@ function compile({testModule, publicPath, loaderOptions}) {
                                 {
                                     loader: "html-loader",
                                     options: {
-                                        attrs: ["img:src", "link:href"],
+                                        attrs: ["img:src", "link:href", "script:src"],
                                         interpolate: true,
                                     },
                                 },


### PR DESCRIPTION
For peerigon/extract-loader#79
The loader fails to extract scripts for html entry points, and raises an exception when those scripts are ES modules.
These tests expose the issue to help get fixes started.
Please redirect the merge into a new branch to complete the fixes there.