### PR TITLE
Fix interprete js file no loaders

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "cross-env NODE_ENV=test nyc mocha -R spec",
     "posttest": "eslint src test",
     "release": "standard-version",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run build"
   },
   "repository": {

--- a/src/extractLoader.js
+++ b/src/extractLoader.js
@@ -135,7 +135,7 @@ function evalDependencyGraph({loaderContext, src, filename, publicPath = ""}) {
 
                 // If the required file is a js file, we just require it with node's require.
                 // If the required file should be processed by a loader we do not touch it (even if it is a .js file).
-                if (loaders === "" && ext === ".js") {
+                if (loaders === "" && ext === ".js" && givenRelativePath.includes('node_modules')) {
                     // Mark the file as dependency so webpack's watcher is working for the css-loader helper.
                     // Other dependencies are automatically added by loadModule() below
                     loaderContext.addDependency(absolutePath);


### PR DESCRIPTION
When you load bootstrap and jquery from local files, this files are interprete and jQuery variable is undefined report.
![image](https://user-images.githubusercontent.com/451862/99394000-2da1da80-28ac-11eb-8323-90659bba7f80.png)

The work the extract-loader is extract the content more no interprete the current js file.
